### PR TITLE
Remove 'case insensitive' designator on singular unit match regex.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ function getUnit(input: string, language: string) {
     }
     for (const unit of Object.keys(units)) {
       for (const shorthand of units[unit]) {
-        const regex = new RegExp('(?=\\b'+shorthand+'\\b)', 'gi')
+        const regex = new RegExp('(?=\\b'+shorthand+'\\b)', 'g')
         if (input.match(regex)) {
           response = [unit, pluralUnits[unit], shorthand];
         }


### PR DESCRIPTION
At least for English, the units list contains both caps and lowercase options. This becomes important because 't' designates teaspoon and 'T' designates Tablespoon.

In addition to accurately identifying these edge cases 't' and 'T', the matched text is returned and used as the 'originalUnit' later to remove the unit from the ingredient string. This was causing the following commented English test to fail.
"25 lb beef stew chunks (or buy a roast and chop into small cubes)"

Because 'lb' was matching for both 'lb' and 'Lb' in the units list, and 'Lb' comes second, the final match being returned was for 'Lb' so when the unit is later removed via a replace() it tries to remove 'Lb' and finds nothing, so the ingredient text ends up being 'lb beef stew chunks' instead of 'beef stew chunks'